### PR TITLE
Allow higher-precision percentiles

### DIFF
--- a/samplers/samplers.go
+++ b/samplers/samplers.go
@@ -55,7 +55,8 @@ func (p *Percentile) String() string {
 	if len(p.stringValue) == 0 {
 		v := p.Value
 		_, fraction := math.Modf(v)
-		for fraction > 0 {
+		// Ensure percentiles are at least 2 digits, trim rounding error:
+		for v < 10 || fraction > 0.01 {
 			v *= 10
 			_, fraction = math.Modf(v)
 		}

--- a/server.go
+++ b/server.go
@@ -120,7 +120,7 @@ type Server struct {
 	shutdown chan struct{}
 	httpQuit bool
 
-	HistogramPercentiles []float64
+	HistogramPercentiles []samplers.Percentile
 
 	plugins   []plugins.Plugin
 	pluginMtx sync.Mutex
@@ -269,7 +269,9 @@ func NewFromConfig(logger *logrus.Logger, conf Config) (*Server, error) {
 	ret.synchronizeInterval = conf.SynchronizeWithInterval
 
 	ret.TagsAsMap = mappedTags
-	ret.HistogramPercentiles = conf.Percentiles
+	for _, per := range conf.Percentiles {
+		ret.HistogramPercentiles = append(ret.HistogramPercentiles, samplers.Percentile{Value: per})
+	}
 	ret.HistogramAggregates.Value = 0
 	for _, agg := range conf.Aggregates {
 		ret.HistogramAggregates.Value += samplers.AggregatesLookup[agg]


### PR DESCRIPTION
<!-- Checklist For PRs

* Ensure you've written tests where applicable
* Add a CHANGELOG.md entry describing your change, thank yourself!
* Document any changes to metrics or configuration
-->


#### Summary
<!-- Simple summary of what the code does or what you have changed. -->
Allows percentiles of more than 2 digits precision.

#### Motivation
<!-- Why are you making this change? -->
Previously, percentile string representations were truncated at 2 digits. For example, `0.999` would render as `.99percentile`.

#### Test plan
<!-- How did you test this change? This can be as simple as “I wrote automated tests.” -->
Added unit test for higher-precision percentiles.

#### Rollout/monitoring/revert plan
<!-- Instructions for deploying, monitoring, and reverting this change. -->
n/a