### PR TITLE
Add generic metrics sink

### DIFF
--- a/config.go
+++ b/config.go
@@ -28,6 +28,11 @@ type Config struct {
 	FlushWatchdogMissedFlushes                int       `yaml:"flush_watchdog_missed_flushes"`
 	ForwardAddress                            string    `yaml:"forward_address"`
 	ForwardUseGrpc                            bool      `yaml:"forward_use_grpc"`
+	GenericEndpoint                           string    `yaml:"generic_endpoint"`
+	GenericBatchSize                          int       `yaml:"generic_batch_size"`
+	GenericSource                             string    `yaml:"generic_source"`
+	GenericEnvironment                        string    `yaml:"generic_environment"`
+	GenericNamespace                          string    `yaml:"generic_namespace"`
 	GrpcAddress                               string    `yaml:"grpc_address"`
 	Hostname                                  string    `yaml:"hostname"`
 	HTTPAddress                               string    `yaml:"http_address"`

--- a/server.go
+++ b/server.go
@@ -47,6 +47,7 @@ import (
 	"github.com/stripe/veneur/sinks/datadog"
 	"github.com/stripe/veneur/sinks/debug"
 	"github.com/stripe/veneur/sinks/falconer"
+	"github.com/stripe/veneur/sinks/generic"
 	"github.com/stripe/veneur/sinks/kafka"
 	"github.com/stripe/veneur/sinks/lightstep"
 	"github.com/stripe/veneur/sinks/signalfx"
@@ -510,6 +511,22 @@ func NewFromConfig(logger *logrus.Logger, conf Config) (*Server, error) {
 			return ret, err
 		}
 		ret.metricSinks = append(ret.metricSinks, ddSink)
+	}
+
+	if conf.GenericEndpoint != "" {
+		gmSink, err := generic.NewGenericMetricSink(
+			log,
+			ret.HTTPClient,
+			conf.GenericEndpoint,
+			conf.GenericBatchSize,
+			conf.GenericSource,
+			conf.GenericEnvironment,
+			conf.GenericNamespace,
+		)
+		if err != nil {
+			return ret, err
+		}
+		ret.metricSinks = append(ret.metricSinks, gmSink)
 	}
 
 	// Configure tracing sinks

--- a/server.go
+++ b/server.go
@@ -517,6 +517,7 @@ func NewFromConfig(logger *logrus.Logger, conf Config) (*Server, error) {
 		gmSink, err := generic.NewGenericMetricSink(
 			log,
 			ret.HTTPClient,
+			nil,
 			conf.GenericEndpoint,
 			conf.GenericBatchSize,
 			conf.GenericSource,

--- a/sinks/generic/generic.go
+++ b/sinks/generic/generic.go
@@ -95,12 +95,7 @@ func (gm *GenericMetricSink) Flush(ctx context.Context, metrics []samplers.Inter
 }
 
 func (gm *GenericMetricSink) flushBatch(metrics []samplers.InterMetric) {
-	genMetrics := GenericMetrics{
-		Metrics:     gm.convertInterToGeneric(metrics),
-		Environment: gm.Environment,
-		Namespace:   gm.Namespace,
-	}
-
+	genMetrics := gm.convertInterToGeneric(metrics)
 	err := vhttp.PostHelper(
 		context.TODO(),
 		gm.httpClient,
@@ -125,7 +120,7 @@ func (gm *GenericMetricSink) flushBatch(metrics []samplers.InterMetric) {
 	}
 }
 
-func (gm *GenericMetricSink) convertInterToGeneric(metrics []samplers.InterMetric) []GenericMetric {
+func (gm *GenericMetricSink) convertInterToGeneric(metrics []samplers.InterMetric) GenericMetrics {
 	var genMetrics []GenericMetric
 	for _, metric := range metrics {
 		inTags := append(metric.Tags, gm.Tags...)
@@ -139,7 +134,11 @@ func (gm *GenericMetricSink) convertInterToGeneric(metrics []samplers.InterMetri
 		}
 		genMetrics = append(genMetrics, genMetric)
 	}
-	return genMetrics
+	return GenericMetrics{
+		Environment: gm.Environment,
+		Namespace:   gm.Namespace,
+		Metrics:     genMetrics,
+	}
 }
 
 // FlushOtherSamples does nothing; currently this sink only supports metrics.

--- a/sinks/generic/generic.go
+++ b/sinks/generic/generic.go
@@ -1,0 +1,146 @@
+package generic
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/sirupsen/logrus"
+	vhttp "github.com/stripe/veneur/http"
+	"github.com/stripe/veneur/samplers"
+	"github.com/stripe/veneur/sinks"
+	"github.com/stripe/veneur/ssf"
+	"github.com/stripe/veneur/trace"
+)
+
+// GenericMetricSink flushes batches of metrics in JSON to a configured endpoint.
+type GenericMetricSink struct {
+	log         *logrus.Logger
+	traceClient *trace.Client
+	httpClient  *http.Client
+	Tags        []string
+	Endpoint    string
+	BatchSize   int
+	Source      string
+	Environment string
+	Namespace   string
+}
+
+// GenericMetric represents a single metric.
+type GenericMetric struct {
+	Metric string            `json:"metric"`
+	Value  float64           `json:"value"`
+	Source string            `json:"source"`
+	At     float64           `json:"at"`
+	Tags   map[string]string `json:"tags"`
+}
+
+// GenericMetrics encapsulates a batch of metrics, with their common environment and namespace.
+type GenericMetrics struct {
+	Metrics     []GenericMetric `json:"metrics"`
+	Environment string          `json:"environment"`
+	Namespace   string          `json:"namespace"`
+}
+
+var _ sinks.MetricSink = &GenericMetricSink{}
+
+// NewGenericMetricSink returns a new generic metrics sink.
+func NewGenericMetricSink(
+	log *logrus.Logger,
+	httpClient *http.Client,
+	tags []string,
+	endpoint string,
+	batchSize int,
+	source string,
+	environment string,
+	namespace string,
+) (*GenericMetricSink, error) {
+	ret := &GenericMetricSink{
+		log:         log,
+		httpClient:  httpClient,
+		Tags:        tags,
+		Endpoint:    endpoint,
+		BatchSize:   batchSize,
+		Source:      source,
+		Environment: environment,
+		Namespace:   namespace,
+	}
+	return ret, nil
+}
+
+// Name returns the sink's name.
+func (gm *GenericMetricSink) Name() string {
+	return "generic"
+}
+
+// Start sets the trace client for the sink.
+func (gm *GenericMetricSink) Start(client *trace.Client) error {
+	gm.traceClient = client
+	return nil
+}
+
+// Flush flushes accumulated metrics.
+func (gm *GenericMetricSink) Flush(ctx context.Context, metrics []samplers.InterMetric) error {
+	var batchSize int
+	for len(metrics) > 0 {
+		if len(metrics) > gm.BatchSize {
+			batchSize = gm.BatchSize
+		} else {
+			batchSize = len(metrics)
+		}
+		batch := metrics[:batchSize]
+		metrics = metrics[batchSize:]
+		gm.flushBatch(batch)
+	}
+	return nil
+}
+
+func (gm *GenericMetricSink) flushBatch(metrics []samplers.InterMetric) {
+	genMetrics := GenericMetrics{
+		Metrics:     gm.convertInterToGeneric(metrics),
+		Environment: gm.Environment,
+		Namespace:   gm.Namespace,
+	}
+
+	err := vhttp.PostHelper(
+		context.TODO(),
+		gm.httpClient,
+		gm.traceClient,
+		http.MethodPost,
+		gm.Endpoint,
+		genMetrics,
+		"flush_metrics",
+		false,
+		nil,
+		gm.log,
+	)
+	if err == nil {
+		gm.log.WithField(
+			"metrics", len(metrics),
+		).Info("Completed flushing generic metrics")
+	} else {
+		gm.log.WithFields(logrus.Fields{
+			"metrics":       len(metrics),
+			logrus.ErrorKey: err,
+		}).Warn("Error flushing generic metrics")
+	}
+}
+
+func (gm *GenericMetricSink) convertInterToGeneric(metrics []samplers.InterMetric) []GenericMetric {
+	var genMetrics []GenericMetric
+	for _, metric := range metrics {
+		inTags := append(metric.Tags, gm.Tags...)
+		outTags := samplers.ParseTagSliceToMap(inTags)
+		genMetric := GenericMetric{
+			Metric: metric.Name,
+			Value:  metric.Value,
+			Source: gm.Source,
+			At:     float64(metric.Timestamp),
+			Tags:   outTags,
+		}
+		genMetrics = append(genMetrics, genMetric)
+	}
+	return genMetrics
+}
+
+// FlushOtherSamples does nothing; currently this sink only supports metrics.
+func (gm *GenericMetricSink) FlushOtherSamples(ctx context.Context, samples []ssf.SSFSample) {}

--- a/sinks/generic/generic_test.go
+++ b/sinks/generic/generic_test.go
@@ -3,7 +3,6 @@ package generic
 import (
 	"compress/zlib"
 	"context"
-	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -18,11 +17,9 @@ import (
 )
 
 type GenericRoundTripper struct {
-	Endpoint      string
-	Contains      string
-	GotCalled     bool
-	ThingReceived bool
-	Contents      string
+	Endpoint string
+	Called   int
+	Contents []string
 }
 
 func (rt *GenericRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
@@ -34,89 +31,18 @@ func (rt *GenericRoundTripper) RoundTrip(req *http.Request) (*http.Response, err
 		}
 		body, _ := ioutil.ReadAll(bstream)
 		defer bstream.Close()
-		if rt.Contains != "" {
-			if strings.Contains(string(body), rt.Contains) {
-				rt.ThingReceived = true
-			}
-		}
-		rt.Contents = string(body)
-
+		rt.Called++
+		rt.Contents = append(rt.Contents, string(body))
 		rec.Code = http.StatusOK
-		rt.GotCalled = true
 	}
 
 	return rec.Result(), nil
 }
 
-func TestConvertInterToGeneric(t *testing.T) {
-	gmSink := GenericMetricSink{
-		Source:      "source",
-		Environment: "environment",
-		Namespace:   "namespace",
-	}
-	intMetric := samplers.InterMetric{
-		Name:      "foo.bar.baz",
-		Timestamp: time.Now().Unix(),
-		Value:     float64(42),
-		Tags:      []string{"fnord:xyzzy", "qux:quux"},
-		Type:      samplers.CounterMetric,
-	}
-	genMetrics := gmSink.convertInterToGeneric([]samplers.InterMetric{intMetric})
-	expectedTags := map[string]string{
-		"fnord": "xyzzy",
-		"qux":   "quux",
-	}
-	assert.Equal(t, fmt.Sprintf("%s", expectedTags), fmt.Sprintf("%s", genMetrics[0].Tags))
-}
-
-func TestAddServerTags(t *testing.T) {
-	gmSink := GenericMetricSink{
-		Tags:        []string{"snowy:plover", "plugh:bletch"},
-		Source:      "source",
-		Environment: "environment",
-		Namespace:   "namespace",
-	}
-	intMetric := samplers.InterMetric{
-		Name:      "foo.bar.baz",
-		Timestamp: time.Now().Unix(),
-		Value:     float64(42),
-		Tags:      []string{"fnord:xyzzy", "qux:quux"},
-		Type:      samplers.CounterMetric,
-	}
-	genMetrics := gmSink.convertInterToGeneric([]samplers.InterMetric{intMetric})
-	expectedTags := map[string]string{
-		"snowy": "plover",
-		"plugh": "bletch",
-		"fnord": "xyzzy",
-		"qux":   "quux",
-	}
-	assert.Equal(t, fmt.Sprintf("%s", expectedTags), fmt.Sprintf("%s", genMetrics[0].Tags))
-}
-
-func TestFlush(t *testing.T) {
-	endpoint := "/fooendpoint"
-	source := "foo-source"
-	environment := "bar-environment"
-	namespace := "baz-namespace"
-
-	transport := &GenericRoundTripper{
-		Endpoint: endpoint,
-	}
-	gmSink, err := NewGenericMetricSink(
-		logrus.New(),
-		&http.Client{Transport: transport},
-		[]string{},
-		endpoint,
-		1000,
-		source,
-		environment,
-		namespace,
-	)
-	assert.NoError(t, err)
-
+func basicInterMetrics() []samplers.InterMetric {
 	ts0 := time.Date(1955, time.November, 5, 6, 0, 0, 0, time.UTC)
 	ts1 := ts0.Add(1 * time.Second)
-	inMetrics := []samplers.InterMetric{
+	interMetrics := []samplers.InterMetric{
 		{
 			Name:      "counter.foo",
 			Timestamp: ts0.Unix(),
@@ -132,39 +58,162 @@ func TestFlush(t *testing.T) {
 			Type:      samplers.GaugeMetric,
 		},
 	}
+	return interMetrics
+}
 
-	expectMetrics := GenericMetrics{
-		Metrics: []GenericMetric{
-			{
-				Metric: inMetrics[0].Name,
-				Value:  inMetrics[0].Value,
-				Source: source,
-				At:     float64(inMetrics[0].Timestamp),
-				Tags: map[string]string{
-					"fnord": "xyzzy",
-					"qux":   "quux",
-				},
-			},
-			{
-				Metric: inMetrics[1].Name,
-				Value:  inMetrics[1].Value,
-				Source: source,
-				At:     float64(inMetrics[1].Timestamp),
-				Tags: map[string]string{
-					"bletch": "frotz",
-					"fax":    "fox",
-				},
-			},
-		},
+func getInterMetricsMany(n int) []samplers.InterMetric {
+	interMetrics := basicInterMetrics()
+	var interMetricsMany []samplers.InterMetric
+	for i := 0; i < n; i++ {
+		interMetricsMany = append(interMetricsMany, interMetrics[i%len(interMetrics)])
+	}
+	return interMetricsMany
+}
+
+func getExpectedGenericMetrics(
+	source string,
+	environment string,
+	namespace string,
+	serverTags []string,
+	interMetrics []samplers.InterMetric,
+) GenericMetrics {
+	genericMetrics := GenericMetrics{
 		Environment: environment,
 		Namespace:   namespace,
 	}
-	var gotMetrics GenericMetrics
+	for _, metric := range interMetrics {
+		tags := append(metric.Tags, serverTags...)
+		genMetric := GenericMetric{
+			Metric: metric.Name,
+			Value:  metric.Value,
+			Source: source,
+			At:     float64(metric.Timestamp),
+			Tags:   samplers.ParseTagSliceToMap(tags),
+		}
+		genericMetrics.Metrics = append(genericMetrics.Metrics, genMetric)
+	}
+	return genericMetrics
+}
 
-	err = gmSink.Flush(context.TODO(), inMetrics)
+func getTestSink(
+	httpClient *http.Client,
+	tags []string,
+	endpoint string,
+	batchSize int,
+	source string,
+	environment string,
+	namespace string,
+) *GenericMetricSink {
+	return &GenericMetricSink{
+		log:         logrus.New(),
+		httpClient:  httpClient,
+		Tags:        tags,
+		Endpoint:    endpoint,
+		BatchSize:   batchSize,
+		Source:      source,
+		Environment: environment,
+		Namespace:   namespace,
+	}
+}
+
+const (
+	defaultSource      = "source"
+	defaultEnvironment = "environment"
+	defaultNamespace   = "namespace"
+)
+
+func defaultTestSink() *GenericMetricSink {
+	return getTestSink(
+		nil,
+		[]string{},
+		"",
+		10,
+		defaultSource,
+		defaultEnvironment,
+		defaultNamespace,
+	)
+}
+
+func getRoundTripTestSink(endpoint string, batchSize int) (*GenericMetricSink, *GenericRoundTripper) {
+	transport := &GenericRoundTripper{
+		Endpoint: endpoint,
+	}
+	sink := getTestSink(
+		&http.Client{Transport: transport},
+		[]string{},
+		endpoint,
+		batchSize,
+		defaultSource,
+		defaultEnvironment,
+		defaultNamespace,
+	)
+	return sink, transport
+}
+
+func TestConvertInterToGeneric(t *testing.T) {
+	gmSink := defaultTestSink()
+	interMetrics := []samplers.InterMetric{
+		{
+			Name:      "foo.bar.baz",
+			Timestamp: time.Now().Unix(),
+			Value:     float64(42),
+			Tags:      []string{"fnord:xyzzy", "qux:quux"},
+			Type:      samplers.CounterMetric,
+		},
+	}
+	expected := getExpectedGenericMetrics(defaultSource, defaultEnvironment, defaultNamespace, []string{}, interMetrics)
+	genericMetrics := gmSink.convertInterToGeneric(interMetrics)
+	assert.Equal(t, expected, genericMetrics)
+}
+
+func TestAddServerTags(t *testing.T) {
+	serverTags := []string{"snowy:plover", "plugh:bletch"}
+	gmSink := getTestSink(
+		nil,
+		serverTags,
+		"",
+		10,
+		defaultSource,
+		defaultEnvironment,
+		defaultNamespace,
+	)
+	interMetrics := basicInterMetrics()
+	expected := getExpectedGenericMetrics(defaultSource, defaultEnvironment, defaultNamespace, serverTags, interMetrics)
+	genericMetrics := gmSink.convertInterToGeneric(interMetrics)
+	assert.Equal(t, expected, genericMetrics)
+}
+
+func TestFlush(t *testing.T) {
+	gmSink, transport := getRoundTripTestSink("/endpoint", 10)
+
+	var gotMetrics GenericMetrics
+	interMetrics := basicInterMetrics()
+	expected := getExpectedGenericMetrics(defaultSource, defaultEnvironment, defaultNamespace, []string{}, interMetrics)
+
+	err := gmSink.Flush(context.TODO(), interMetrics)
 	assert.NoError(t, err)
-	assert.Equal(t, true, transport.GotCalled, "Did not call metrics endpoint")
-	err = json.Unmarshal([]byte(transport.Contents), &gotMetrics)
+	assert.Equal(t, 1, transport.Called)
+	err = json.Unmarshal([]byte(transport.Contents[0]), &gotMetrics)
 	assert.NoError(t, err)
-	assert.Equal(t, expectMetrics, gotMetrics)
+	assert.Equal(t, expected, gotMetrics)
+}
+
+func TestFlushBatch(t *testing.T) {
+	gmSink, transport := getRoundTripTestSink("/endpoint", 5)
+
+	interMetrics := getInterMetricsMany(10)
+	expected := []GenericMetrics{
+		getExpectedGenericMetrics(defaultSource, defaultEnvironment, defaultNamespace, []string{}, interMetrics[:5]),
+		getExpectedGenericMetrics(defaultSource, defaultEnvironment, defaultNamespace, []string{}, interMetrics[5:]),
+	}
+
+	err := gmSink.Flush(context.TODO(), interMetrics)
+	assert.NoError(t, err)
+	assert.Equal(t, 2, transport.Called)
+	for i := 0; i < 2; i++ {
+		var gotMetrics GenericMetrics
+		err = json.Unmarshal([]byte(transport.Contents[i]), &gotMetrics)
+		assert.NoError(t, err)
+		assert.Equal(t, expected[i], gotMetrics)
+	}
 }

--- a/sinks/generic/generic_test.go
+++ b/sinks/generic/generic_test.go
@@ -1,0 +1,170 @@
+package generic
+
+import (
+	"compress/zlib"
+	"context"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stripe/veneur/samplers"
+	"k8s.io/apimachinery/pkg/util/json"
+)
+
+type GenericRoundTripper struct {
+	Endpoint      string
+	Contains      string
+	GotCalled     bool
+	ThingReceived bool
+	Contents      string
+}
+
+func (rt *GenericRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	rec := httptest.NewRecorder()
+	if strings.HasPrefix(req.URL.Path, rt.Endpoint) {
+		bstream := req.Body
+		if req.Header.Get("Content-Encoding") == "deflate" {
+			bstream, _ = zlib.NewReader(req.Body)
+		}
+		body, _ := ioutil.ReadAll(bstream)
+		defer bstream.Close()
+		if rt.Contains != "" {
+			if strings.Contains(string(body), rt.Contains) {
+				rt.ThingReceived = true
+			}
+		}
+		rt.Contents = string(body)
+
+		rec.Code = http.StatusOK
+		rt.GotCalled = true
+	}
+
+	return rec.Result(), nil
+}
+
+func TestConvertInterToGeneric(t *testing.T) {
+	gmSink := GenericMetricSink{
+		Source:      "source",
+		Environment: "environment",
+		Namespace:   "namespace",
+	}
+	intMetric := samplers.InterMetric{
+		Name:      "foo.bar.baz",
+		Timestamp: time.Now().Unix(),
+		Value:     float64(42),
+		Tags:      []string{"fnord:xyzzy", "qux:quux"},
+		Type:      samplers.CounterMetric,
+	}
+	genMetrics := gmSink.convertInterToGeneric([]samplers.InterMetric{intMetric})
+	expectedTags := map[string]string{
+		"fnord": "xyzzy",
+		"qux":   "quux",
+	}
+	assert.Equal(t, fmt.Sprintf("%s", expectedTags), fmt.Sprintf("%s", genMetrics[0].Tags))
+}
+
+func TestAddServerTags(t *testing.T) {
+	gmSink := GenericMetricSink{
+		Tags:        []string{"snowy:plover", "plugh:bletch"},
+		Source:      "source",
+		Environment: "environment",
+		Namespace:   "namespace",
+	}
+	intMetric := samplers.InterMetric{
+		Name:      "foo.bar.baz",
+		Timestamp: time.Now().Unix(),
+		Value:     float64(42),
+		Tags:      []string{"fnord:xyzzy", "qux:quux"},
+		Type:      samplers.CounterMetric,
+	}
+	genMetrics := gmSink.convertInterToGeneric([]samplers.InterMetric{intMetric})
+	expectedTags := map[string]string{
+		"snowy": "plover",
+		"plugh": "bletch",
+		"fnord": "xyzzy",
+		"qux":   "quux",
+	}
+	assert.Equal(t, fmt.Sprintf("%s", expectedTags), fmt.Sprintf("%s", genMetrics[0].Tags))
+}
+
+func TestFlush(t *testing.T) {
+	endpoint := "/fooendpoint"
+	source := "foo-source"
+	environment := "bar-environment"
+	namespace := "baz-namespace"
+
+	transport := &GenericRoundTripper{
+		Endpoint: endpoint,
+	}
+	gmSink, err := NewGenericMetricSink(
+		logrus.New(),
+		&http.Client{Transport: transport},
+		[]string{},
+		endpoint,
+		1000,
+		source,
+		environment,
+		namespace,
+	)
+	assert.NoError(t, err)
+
+	ts0 := time.Date(1955, time.November, 5, 6, 0, 0, 0, time.UTC)
+	ts1 := ts0.Add(1 * time.Second)
+	inMetrics := []samplers.InterMetric{
+		{
+			Name:      "counter.foo",
+			Timestamp: ts0.Unix(),
+			Value:     float64(42),
+			Tags:      []string{"fnord:xyzzy", "qux:quux"},
+			Type:      samplers.CounterMetric,
+		},
+		{
+			Name:      "gauge.bar",
+			Timestamp: ts1.Unix(),
+			Value:     float64(42),
+			Tags:      []string{"bletch:frotz", "fax:fox"},
+			Type:      samplers.GaugeMetric,
+		},
+	}
+
+	expectMetrics := GenericMetrics{
+		Metrics: []GenericMetric{
+			{
+				Metric: inMetrics[0].Name,
+				Value:  inMetrics[0].Value,
+				Source: source,
+				At:     float64(inMetrics[0].Timestamp),
+				Tags: map[string]string{
+					"fnord": "xyzzy",
+					"qux":   "quux",
+				},
+			},
+			{
+				Metric: inMetrics[1].Name,
+				Value:  inMetrics[1].Value,
+				Source: source,
+				At:     float64(inMetrics[1].Timestamp),
+				Tags: map[string]string{
+					"bletch": "frotz",
+					"fax":    "fox",
+				},
+			},
+		},
+		Environment: environment,
+		Namespace:   namespace,
+	}
+	var gotMetrics GenericMetrics
+
+	err = gmSink.Flush(context.TODO(), inMetrics)
+	assert.NoError(t, err)
+	assert.Equal(t, true, transport.GotCalled, "Did not call metrics endpoint")
+	err = json.Unmarshal([]byte(transport.Contents), &gotMetrics)
+	assert.NoError(t, err)
+	assert.Equal(t, expectMetrics, gotMetrics)
+}


### PR DESCRIPTION
<!-- Checklist For PRs

* Ensure you've written tests where applicable
* Add a CHANGELOG.md entry describing your change, thank yourself!
* Document any changes to metrics or configuration
-->


#### Summary
<!-- Simple summary of what the code does or what you have changed. -->
Adds a sink that flushes metrics to an HTTP POST endpoint in a "generic" JSON format.

JIRA: [METRICS-599](https://jira.lyft.net/browse/METRICS-599)

#### Motivation
<!-- Why are you making this change? -->
Connect Veneur to a vendor-agnostic metrics proxy.

#### Test plan
<!-- How did you test this change? This can be as simple as “I wrote automated tests.” -->
* Added unit tests.
* Verified flush to proxy instance in local integration testing.

#### Rollout/monitoring/revert plan
<!-- Instructions for deploying, monitoring, and reverting this change. -->
Deployment will be via corresponding stats agent sidecar PR.